### PR TITLE
When log in, do not use only email.

### DIFF
--- a/src/app/Login/index.tsx
+++ b/src/app/Login/index.tsx
@@ -22,14 +22,14 @@ export const loader = (async () => {
 
 export const action = (async ({ request }) => {
   const data = await request.formData();
-  const email = data.get("email");
+  const identifier = data.get("identifier");
   const password = data.get("password");
   // TODO: better validation?
-  if (typeof email !== "string" || typeof password !== "string") {
-    throw new Error(`Validation error: ${{ email, password }}`);
+  if (typeof identifier !== "string" || typeof password !== "string") {
+    throw new Error(`Validation error: ${{ identifier, password }}`);
   }
   const resp = await atp.login({
-    identifier: email,
+    identifier: identifier,
     password: password,
   });
   if (!resp.success) {
@@ -53,10 +53,10 @@ function LoginRoute() {
       </div>
       <Form method="post" className={styles.form}>
         <TextInput
-          label="Email"
-          name="email"
+          label="Identifier (handle or email)"
+          name="identifier"
           type="text"
-          placeholder="you@example.com"
+          placeholder="you.bsky.social"
         />
         <TextInput label="Password" name="password" type="password" />
         <Button

--- a/src/app/Login/index.tsx
+++ b/src/app/Login/index.tsx
@@ -55,7 +55,7 @@ function LoginRoute() {
         <TextInput
           label="Email"
           name="email"
-          type="email"
+          type="text"
           placeholder="you@example.com"
         />
         <TextInput label="Password" name="password" type="password" />


### PR DESCRIPTION
Hi! I'm using Flat every day.

I would like to log in with a string others than email.
Now, using here: (i think)

https://atproto.com/lexicons/com-atproto-session#comatprotosessioncreate
https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/session/create.json

In fact, we can log in with no problem even if `<input type="email">` to `<input type="text">`.
As you probably already know, when sign in, can use a email, custom domain and did.
This PR's priority is very lower.

Best regards.