### PR TITLE
Fixed a problem in which the correct parent.root was not specified in replies

### DIFF
--- a/src/app/post/lib/postToReply.ts
+++ b/src/app/post/lib/postToReply.ts
@@ -7,7 +7,7 @@ export function postToReply(
   const parent = { cid: replyTarget.post.cid, uri: replyTarget.post.uri };
   const root =
     replyTarget.reply && AppBskyFeedDefs.isPostView(replyTarget.reply.root)
-      ? replyTarget.reply.root : ((replyTarget.post.record as PostView)?.reply as AppBskyFeedPost.ReplyRef).root ?? parent;
+      ? replyTarget.reply.root : ((replyTarget.post.record as PostView)?.reply as AppBskyFeedPost.ReplyRef)?.root ?? parent;
   return {
     handle: replyTarget.post.author.handle,
     parent,

--- a/src/app/post/lib/postToReply.ts
+++ b/src/app/post/lib/postToReply.ts
@@ -1,15 +1,36 @@
-import { AppBskyFeedDefs, AppBskyFeedPost } from "@atproto/api";
-import {PostView} from "@atproto/api/dist/client/types/app/bsky/feed/defs";
+import {
+  AppBskyFeedDefs,
+  AppBskyFeedPost,
+  ComAtprotoRepoStrongRef,
+} from "@atproto/api";
 
-export function postToReply(
-  replyTarget: AppBskyFeedDefs.FeedViewPost,
-): AppBskyFeedPost.ReplyRef {
-  const parent = { cid: replyTarget.post.cid, uri: replyTarget.post.uri };
-  const root =
-    replyTarget.reply && AppBskyFeedDefs.isPostView(replyTarget.reply.root)
-      ? replyTarget.reply.root : ((replyTarget.post.record as PostView)?.reply as AppBskyFeedPost.ReplyRef)?.root ?? parent;
+type FeedViewPost = AppBskyFeedDefs.FeedViewPost;
+type ReplyRef = AppBskyFeedPost.ReplyRef;
+type StrongRef = ComAtprotoRepoStrongRef.Main;
+
+const isPostRecord = AppBskyFeedPost.isRecord;
+const isPostView = AppBskyFeedDefs.isPostView;
+
+export function postToReply(replyTarget: FeedViewPost): ReplyRef {
+  const parent: StrongRef = {
+    cid: replyTarget.post.cid,
+    uri: replyTarget.post.uri,
+  };
+
+  const root: StrongRef = (() => {
+    if (replyTarget.reply && isPostView(replyTarget.reply.root)) {
+      return replyTarget.reply.root;
+    } else if (
+        isPostRecord(replyTarget.post.record) &&
+        replyTarget.post.record.reply
+    ) {
+      return replyTarget.post.record.reply.root;
+    } else {
+      return parent;
+    }
+  })();
+
   return {
-    handle: replyTarget.post.author.handle,
     parent,
     root,
   };

--- a/src/app/post/lib/postToReply.ts
+++ b/src/app/post/lib/postToReply.ts
@@ -1,4 +1,5 @@
 import { AppBskyFeedDefs, AppBskyFeedPost } from "@atproto/api";
+import {PostView} from "@atproto/api/dist/client/types/app/bsky/feed/defs";
 
 export function postToReply(
   replyTarget: AppBskyFeedDefs.FeedViewPost,
@@ -6,8 +7,7 @@ export function postToReply(
   const parent = { cid: replyTarget.post.cid, uri: replyTarget.post.uri };
   const root =
     replyTarget.reply && AppBskyFeedDefs.isPostView(replyTarget.reply.root)
-      ? replyTarget.reply.root
-      : parent;
+      ? replyTarget.reply.root : ((replyTarget.post.record as PostView)?.reply as AppBskyFeedPost.ReplyRef).root ?? parent;
   return {
     handle: replyTarget.post.author.handle,
     parent,


### PR DESCRIPTION
If replyTarget.post.record.reply.root exists, instead of replyTarget.reply.root, it is now specified as root.

Sorry for the messy code writing.......